### PR TITLE
Lazy load

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,30 @@
 Yet another react grid component.
 
 Props:
-- rows[][]              // where each row is an array of cells
+- getRowsFunction: function(beginIndex, numItems){ ... return promise;} // A function which returns a Promise, which resolves with an array of arrays
 - numTotalRows          // total rows in the system. We use this to setup scrolling. Needed this for lazy loading (WIP)
 - columnDefinition [{}] // contains information about each column {title, className}
 - rowHeight             // px height of each row; For now, this must be fixed and same for all rows
+- numBufferRows         // number of rows to keep as scroll buffer on either side of the viewport. Optional. default 10
+- pageSize              // number of rows to request each time more rows are requested. Optional. default 60
 
 
-### Current state
+### Current state and open issues
 
-The demo page scrolls through ~~a million rows~~ almost a million rows easily. Well actually any number of rows which you can fit within 33554428 pixels; that is the maximum height of a div in Chrome; I have some ideas on how to fix this issue, but that fix will come later.
+- The demo page scrolls through ~~a million rows~~ almost a million rows easily. Well actually any number of rows which you can fit within 33554428 pixels; that is the maximum height of a div in Chrome; I have some ideas on how to fix this issue, but that fix will come later.
+- FireFox seems to ignore the height attribute if it past a certain number; This means that in FF the scrollbar starts out as bif and gets smaller as more rows are loaded.
 
-At the moment, lazy loading does not work and all the data must already be in the rows prop.
 
-### Coming features
+### Breaking changes in 0.1.0
 
-- Lazy loading
+- props.rows is no longer supported. simian-grid will always look to fetch data through props.getRowsFunction.
+
+
+### In the pipeline
+
+- Supply custom column header elements
+- Supply custom cell component elements
+
 
 ### How to build example
 
@@ -34,7 +43,7 @@ You can use simian-grid in your own project by installing it thus,
 ```
 $ npm install simian-grid --save-dev
 ```
-But I strongly advise you look at a more mature solution like Griddle. simian-grid is still in development and it is very limited in functionality. Watch the repo, or my twitter account for updates. If you find a bug, of if you have a feature request, please log an issue at https://github.com/akshat1/simian-grid/issues.
+But I strongly advise you look at a more mature solution like Griddle. simian-grid is still in development and it is very limited in functionality. Watch the repo, or my twitter account @SimiaCode for updates. If you find a bug, of if you have a feature request, please log an issue at https://github.com/akshat1/simian-grid/issues.
 
 
 ### Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-grid",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "React based infinite scrolling grid",
   "main": "lib/simian-grid.js",
   "scripts": {

--- a/src/js/demo.js
+++ b/src/js/demo.js
@@ -59,27 +59,27 @@ var columnDefinition = [{
 
 
 function getRows(from, num) {
-  console.log(`getRows(${from}, ${num})`);
   return new Promise(function(resolve, reject) {
     var rows = generateData(num, dataTemplate);
     if(from !== 0)
       rows.forEach(function(row) {
         row[0] += from; //We already know this is the count; So a little hack instead of changing datagen for now
       });
-    resolve(rows);
+    // Simulate data fetch lag
+    setTimeout(function() {
+      resolve(rows);
+    }, 250);
   });
 }
 
 
 function makeDataModel() {
-  return getRows(0, MAX_ROWS).then(function(rows) {
-    return {
-      columnDefinition: columnDefinition,
-      rowHeight: 40,
-      numTotalRows: MAX_ROWS,
-      rows: rows
-    };
-  });
+  return {
+    columnDefinition: columnDefinition,
+    rowHeight: 40,
+    numTotalRows: MAX_ROWS,
+    getRowsFunction: getRows
+  };
 }
 
 
@@ -97,7 +97,7 @@ function insertStyleRules() {
 
 
 document.addEventListener('DOMContentLoaded', function() {
-  makeDataModel().then(function(model) {
+    var model = makeDataModel();
     window.model = model;
     insertStyleRules();
     var demoRootStyle = {
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', function() {
     ReactDOM.render(
       <div id = 'demoRoot' style = {demoRootStyle}>
         <SimianGrid
-          rows={model.rows}
+          getRowsFunction={model.getRowsFunction}
           numTotalRows={model.numTotalRows}
           columnDefinition={model.columnDefinition}
           rowHeight={model.rowHeight}
@@ -119,5 +119,4 @@ document.addEventListener('DOMContentLoaded', function() {
       </div>,
       document.body
     );
-  });
 });

--- a/src/js/demo.js
+++ b/src/js/demo.js
@@ -115,6 +115,8 @@ document.addEventListener('DOMContentLoaded', function() {
           numTotalRows={model.numTotalRows}
           columnDefinition={model.columnDefinition}
           rowHeight={model.rowHeight}
+          pageSize={100}
+          numBufferRows={25}
         />
       </div>,
       document.body

--- a/src/js/demo.js
+++ b/src/js/demo.js
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', function() {
           columnDefinition={model.columnDefinition}
           rowHeight={model.rowHeight}
           pageSize={100}
-          numBufferRows={25}
+          numBufferRows={50}
         />
       </div>,
       document.body

--- a/src/js/simian-grid.jsx
+++ b/src/js/simian-grid.jsx
@@ -109,7 +109,7 @@ class SimianGrid extends React.Component {
   }
 
 
-  loadMoreRows(loadFrom) {
+  loadMoreRows(loadFrom, howMany) {
     this.props.getRowsFunction(loadFrom, this.props.pageSize || DEFAULT_PAGE_SIZE)
       .then(this.handleNewRows);
   }
@@ -133,17 +133,8 @@ class SimianGrid extends React.Component {
   }
 
 
-  rejectScrollIfLoading(evt) {
-    if (this.state.isLoadingRows) {
-      evt.preventDefault();
-      return true;
-    }
-  }
-
-
   @autobind
   handleWheel(evt) {
-    //this.rejectScrollIfLoading(evt);
     let wrapper = this.refs[REF_NAME.OUTER_WRAPPER];
     let currentScrollTop = wrapper.scrollTop;
     let maxScrollTopAllowed = this.state.maxScrollTopAllowed;
@@ -155,8 +146,6 @@ class SimianGrid extends React.Component {
 
   @autobind
   handleScroll(evt) {
-    //if (this.rejectScrollIfLoading(evt))
-    //  return;
     this.updateSelf();
   }
 
@@ -180,8 +169,7 @@ class SimianGrid extends React.Component {
   getInnerWrapperStyle() {
     return {
       height: this.state.innerWrapperHeight,
-      position: 'relative',
-      overflow: 'hidden'
+      position: 'relative'
     };
   }
 

--- a/src/js/simian-grid.jsx
+++ b/src/js/simian-grid.jsx
@@ -71,7 +71,7 @@ class SimianGrid extends React.Component {
     let state = this.state;
     let props = this.props;
     let isLoadingRows = false;
-    let availRows = addendum.rows || state.rows; //concat without arguments doesn't throw an error
+    let availRows = addendum.rows || state.rows;
     let numAvailRows = availRows.length;
     let rowHeight = props.rowHeight;
     let wrapper = this.refs[REF_NAME.OUTER_WRAPPER];


### PR DESCRIPTION
Breaking change: Data will now be loaded only through props.getRowsFunction; props.rows is no longer supported.
