### PR TITLE
Support rows prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-grid",
-  "version": "0.1.34",
+  "version": "0.2.00",
   "description": "React based infinite scrolling grid",
   "main": "lib/simian-grid.js",
   "scripts": {

--- a/src/js/simian-grid.jsx
+++ b/src/js/simian-grid.jsx
@@ -55,8 +55,7 @@ class SimianGrid extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      innerWrapperHeight: 0,
-      rows: []
+      innerWrapperHeight: 0
     };
   }
 
@@ -69,7 +68,7 @@ class SimianGrid extends React.Component {
     let state = this.state;
     let props = _.merge({}, this.props, nextProps);
     let isLoadingRows = false;
-    let availRows = addendum.rows || state.rows;
+    let availRows = addendum.rows || props.rows;
     let numAvailRows = availRows.length;
     let rowHeight = props.rowHeight;
     let wrapper = this.refs[REF_NAME.OUTER_WRAPPER];
@@ -97,8 +96,7 @@ class SimianGrid extends React.Component {
       upperBound: upperBound,
       tableTopPos: tableTopPos,
       isLoadingRows: isLoadingRows,
-      maxScrollTopAllowed: (numAvailRows - cursorSize + 3) * rowHeight,
-      rows: availRows
+      maxScrollTopAllowed: (numAvailRows - cursorSize + 3) * rowHeight
     }));
 
     if (isMoreRowsRequired) {
@@ -108,18 +106,11 @@ class SimianGrid extends React.Component {
 
 
   loadMoreRows(loadFrom, howMany) {
-    this.props.getRowsFunction(loadFrom, this.props.pageSize || DEFAULT_PAGE_SIZE)
-      .then(this.handleNewRows);
+    let onMoreRowsNeeded = this.props.onMoreRowsNeeded
+    if (typeof onMoreRowsNeeded === 'function')
+      onMoreRowsNeeded(loadFrom, this.props.pageSize || DEFAULT_PAGE_SIZE);
   }
 
-
-  @autobind
-  handleNewRows(rows) {
-    this.updateSelf({
-      rows: this.state.rows.concat(rows),
-      isLoadingRows: false
-    });
-  }
 
   // =============== Events =========================================================================================================
 
@@ -229,7 +220,7 @@ class SimianGrid extends React.Component {
   renderRow(row, index) {
     let evenOdd = index % 2 === 0 ? 'even' : 'odd';
     let renderedCells = [];
-    for (var i = 0, len = row.length; i < len; i++)
+    for (let i = 0, len = row.length; i < len; i++)
       renderedCells.push(this.renderCell(row[i], index, i));
 
     return (
@@ -262,8 +253,8 @@ class SimianGrid extends React.Component {
 
   renderDummyRows(numDummyRows) {
     let colSpan = this.props.columnDefinition.length;
-    var rows = [];
-    for (var i = 0; i < numDummyRows; i++) {
+    let rows = [];
+    for (let i = 0; i < numDummyRows; i++) {
       rows.push(
         <tr className={CLASS_NAME.DUMMY} key={`dummy-row-${i}`}>
           <td style={this.getCellStyle()} colSpan={colSpan}>
@@ -280,7 +271,7 @@ class SimianGrid extends React.Component {
     let state = this.state;
     let lowerBound = state.lowerBound;
     let numRowsToRender = state.upperBound - lowerBound;
-    let rows = state.rows;
+    let rows = this.props.rows;
 
     let renderedRows = this.renderDummyRows(state.numberOfDummyRows);
     for(let i = 0; i < numRowsToRender; i++) {
@@ -316,7 +307,7 @@ class SimianGrid extends React.Component {
 
 
   renderLoadingComponent() {
-    if (this.state.isLoadingRows) {
+    if (this.props.isLoading) {
       return (
         <div className={CLASS_NAME.LOADING_COMPONENT} style={this.getLoadingComponentStyle()}>
           Loading . . .
@@ -341,14 +332,15 @@ class SimianGrid extends React.Component {
 
 
 SimianGrid.propTypes = {
-  getRowsFunction: React.PropTypes.func,
-  numTotalRows: React.PropTypes.number,
-  numBufferRows: React.PropTypes.number,
-  pageSize: React.PropTypes.number,
-  columnDefinition: React.PropTypes.arrayOf(React.PropTypes.shape({
+  onMoreRowsNeeded : React.PropTypes.func,
+  rows             : React.PropTypes.array.isRequired,
+  numTotalRows     : React.PropTypes.number.isRequired,
+  numBufferRows    : React.PropTypes.number,
+  pageSize         : React.PropTypes.number,
+  rowHeight        : React.PropTypes.number.isRequired,
+  columnDefinition : React.PropTypes.arrayOf(React.PropTypes.shape({
     className: React.PropTypes.string
-  })),
-  rowHeight: React.PropTypes.number
+  })).isRequired
 };
 
 

--- a/src/js/simian-grid.jsx
+++ b/src/js/simian-grid.jsx
@@ -1,9 +1,9 @@
 'use strict';
 
-var React = require('react');
-var autobind = require('autobind-decorator');
-var _ = require('lodash');
-var setupResizeHandling = require('element-resize-event');
+const React = require('react');
+const autobind = require('autobind-decorator');
+const _ = require('lodash');
+const setupResizeHandling = require('element-resize-event');
 
 
 function lesser(a, b){
@@ -16,15 +16,15 @@ function greater(a, b){
 }
 
 
-var NUM_BUFFER_ROWS = 10;
-var DEFAULT_PAGE_SIZE = 60;
-var OUTER_WRAPPER_STYLE = {
+const NUM_BUFFER_ROWS = 10;
+const DEFAULT_PAGE_SIZE = 60;
+const OUTER_WRAPPER_STYLE = {
   overflow: 'auto',
   height: '100%',
   width: '100%'
 };
 
-var NO_ROWS_COMPONENT_STYLE = {
+const NO_ROWS_COMPONENT_STYLE = {
   whiteSpace: 'nowrap',
   position: 'absolute',
   fontSize: '5em',
@@ -33,7 +33,7 @@ var NO_ROWS_COMPONENT_STYLE = {
   transform: 'translate(-50%, -50%)'
 };
 
-var CLASS_NAME = {
+const CLASS_NAME = {
   OUTER_WRAPPER: 'simiangrid-wrapper',
   INNER_WRAPPER: 'simiangrid-inner-wrapper',
   EVEN: 'even',
@@ -45,7 +45,7 @@ var CLASS_NAME = {
   LOADING_COMPONENT: 'simian-grid-loading-component'
 };
 
-var REF_NAME = {
+const REF_NAME = {
   OUTER_WRAPPER: 'outer-wrapper',
   INNER_WRAPPER: 'inner-wrapper'
 };


### PR DESCRIPTION
The promise approach adopted in 0.1.x had some issues. Notably, it completely isolated the parent component from the rows. The problem with this is that the parent would not know how much data has been loaded, whether we are still loading data and what not.

However, with rows being a prop, the problem remains of how to ask the parent for more rows. Generally I abhor callbacks between components, relying instead on pubsub or events. However, since simian-grid is meant to be used in different projects, we don't know what PubSub system would be used, so pubsub is out. This leaves us with events. But, this.refs[<ref name>] returns a React component and not a DOM element. So there is no addEventListener and you can not dispatch events. I briefly considered adding addEventListener to SimianGrid component, but then I realised that an event that can not be bubbled, and the corresponding listener come together at the end of the day to what is essentially a callback.

And this is the story of the new onMoreRowsNeeded prop. This is a function meant to accept two arguments (from:int and numItems:int). But instead of returning rows (or a promise containing rows), all this function does is tell the parent that more rows are needed. The parent can then choose to update the rows prop with more rows (or forward the request via Flux or PubSub or Relay to some other data loading mechanism).
