### PR TITLE
Experimental list support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simian-grid",
-  "version": "0.2.01",
+  "version": "0.2.02",
   "description": "React based infinite scrolling grid",
   "main": "lib/simian-grid.js",
   "scripts": {


### PR DESCRIPTION
specify prop noTable={true} to render divs instead of a table. In this mode, each item in rows[] is supposed to be rendered into each of these divs.
